### PR TITLE
誕生年月日のフォームをinputのdate型から年月日のドロップダウンリストに変更

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -1,17 +1,18 @@
 {
-  "name": "vite",
+  "name": "openfisca-japan-dashboard",
   "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "vite",
+      "name": "openfisca-japan-dashboard",
       "version": "0.0.0",
       "dependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
       },
       "devDependencies": {
+        "@types/node": "^18.13.0",
         "@types/react": "^18.0.0",
         "@types/react-dom": "^18.0.0",
         "@vitejs/plugin-react": "^1.3.0",
@@ -483,6 +484,12 @@
       "engines": {
         "node": ">= 8.0.0"
       }
+    },
+    "node_modules/@types/node": {
+      "version": "18.13.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.13.0.tgz",
+      "integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==",
+      "dev": true
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
@@ -1769,6 +1776,12 @@
         "estree-walker": "^2.0.1",
         "picomatch": "^2.2.2"
       }
+    },
+    "@types/node": {
+      "version": "18.13.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.13.0.tgz",
+      "integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==",
+      "dev": true
     },
     "@types/prop-types": {
       "version": "15.7.5",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -12,6 +12,7 @@
     "react-dom": "^18.0.0"
   },
   "devDependencies": {
+    "@types/node": "^18.13.0",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
     "@vitejs/plugin-react": "^1.3.0",

--- a/dashboard/src/components/forms/attributes/Birthday.tsx
+++ b/dashboard/src/components/forms/attributes/Birthday.tsx
@@ -1,29 +1,151 @@
-import { useCallback, useContext } from "react";
+import { useState, useCallback, useContext, useMemo, useEffect } from "react";
 import { HouseholdContext } from "../../../contexts/HouseholdContext";
 
 export const Birthday = ({ personName }: { personName: string }) => {
   const { household, setHousehold } = useContext(HouseholdContext);
 
-  const onChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+  const thisYear = new Date().getFullYear();
+  const [selectedYear, setSelectedYear] = useState(NaN);
+  const [selectedMonth, setSelectedMonth] = useState(NaN);
+  const [selectedDate, setSelectedDate] = useState(NaN);
+
+  // 年月日のドロップダウンリスト
+  const yearArray = [...Array(thisYear - 1900)].map((_, i) =>
+    String(thisYear - i)
+  );
+  const monthArray = [...Array(12)].map((_, i) => String(i + 1));
+
+  // 月末の日付は年・月によって変わる
+  const dateArray = useMemo(() => {
+    if (isNaN(selectedYear) || isNaN(selectedMonth)) {
+      return [...Array(31)].map((_, i) => String(i + 1));
+    }
+    console.log(selectedYear);
+    console.log(isNaN(selectedYear));
+    const lastDate = new Date(selectedYear, selectedMonth, 1);
+    lastDate.setDate(0);
+    return [...Array(lastDate.getDate())].map((_, i) => String(i + 1));
+  }, [selectedYear, selectedMonth]);
+
+  const handleYearChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      setSelectedYear(parseInt(event.currentTarget.value));
+    },
+    []
+  );
+
+  const handleMonthChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      setSelectedMonth(parseInt(event.currentTarget.value));
+    },
+    []
+  );
+
+  const handleDateChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      setSelectedDate(parseInt(event.currentTarget.value));
+    },
+    []
+  );
+
+  // 年月日が変更された時OpenFiscaの計算を行う
+  useEffect(() => {
+    let birthday;
+    if (isNaN(selectedYear) || isNaN(selectedMonth) || isNaN(selectedDate)) {
+      birthday = "";
+    } else {
+      console.log([selectedYear, selectedMonth, selectedDate]);
+      // 年・月が変更され選択されていた日が月末より大きい場合、1日に変更
+      // （例）2020年2月29日（閏年）から年を2021に変更した場合、GUIのフォームと内部状態は2021年2月1日に年と日を変更
+      // 年・月が変更され選択されていた日が月末以下の場合、日は変更しない
+      // （例）2020年2月15日から年を2021に変更した場合、GUIのフォームと内部状態は2021年2月15日に年のみ変更
+      const lastDate = new Date(selectedYear, selectedMonth, 1); // 翌月
+      lastDate.setDate(0); // 当月最終日
+      if (selectedDate > lastDate.getDate()) {
+        setSelectedDate(1);
+      }
+
+      birthday = `${selectedYear.toString().padStart(4, "0")}-${selectedMonth
+        .toString()
+        .padStart(2, "0")}-${selectedDate.toString().padStart(2, "0")}`;
+    }
+
     const newHousehold = {
       ...household,
     };
-    newHousehold.世帯員[personName]["誕生年月日"].ETERNITY =
-      event.currentTarget.value;
+    newHousehold.世帯員[personName]["誕生年月日"].ETERNITY = birthday;
     setHousehold(newHousehold);
-  }, []);
+  }, [selectedYear, selectedMonth, selectedDate]);
 
   return (
     <div className="input-group input-group-lg mb-3">
       <span className="input-group-text">生年月日</span>
-      <input
-        name={"生年月日"}
-        className="form-control"
-        type="date"
-        value={household.世帯員[personName].誕生年月日.ETERNITY}
-        max="2999-12-31"
-        onChange={onChange}
-      />
+      <select className="form-select" onChange={(e) => handleYearChange(e)}>
+        <option value={""} key={0}></option>
+        {yearArray.map((year) => (
+          <option value={year} key={year}>
+            {year}
+          </option>
+        ))}
+      </select>
+      <span className="input-group-text">年</span>
+      <select className="form-select" onChange={(e) => handleMonthChange(e)}>
+        <option value={""} key={0}></option>
+        {monthArray.map((month) => (
+          <option value={month} key={month}>
+            {month}
+          </option>
+        ))}
+      </select>
+      <span className="input-group-text">月</span>
+      <select className="form-select" onChange={(e) => handleDateChange(e)}>
+        <option value={""} key={0}></option>
+        {dateArray.map((date) => (
+          <option value={date} key={date}>
+            {date}
+          </option>
+        ))}
+      </select>
+      <span className="input-group-text">日</span>
     </div>
+
+    /*
+    // inlineフォーム形式
+    <div className="row g-3 align-items-center">
+      <div className="col-auto">
+        <label className="col-form-label">生年月日</label>
+      </div>
+      <div className="col-auto">
+        <select className="form-select">
+          {yearList.map((year) => (
+            <option value={year}>{year}</option>
+          ))}
+        </select>
+      </div>
+      <div className="col-auto">
+        <label className="col-form-label">年</label>
+      </div>
+      <div className="col-auto">
+        <select className="form-select">
+          {[...Array(12)].map((_, i) => (
+            <option value={i + 1}>{i + 1}</option>
+          ))}
+        </select>
+      </div>
+      <div className="col-auto">
+        <label className="col-form-label">月</label>
+      </div>
+      <div className="col-auto">
+        <select className="form-select">
+          {[...Array(31)].map((_, i) => (
+            <option value={i + 1}>{i + 1}</option>
+          ))}
+        </select>
+      </div>
+      <div className="col-auto">
+        <label className="col-form-label">日</label>
+      </div>
+    </div>
+    */
   );
 };


### PR DESCRIPTION
## 課題
従来のinputタグのdate型では、スマートフォンで見るとカレンダーフォーマットで表示され、年をまたぐ変更が月単位で行う必要があり手間だった。

## 修正方法
誕生年月日のフォームをinputのdate型から年月日それぞれのドロップダウンリストに変更した。

## 動作確認

- [x] 修正した部分の影響しそうな箇所をアドホックテストした
